### PR TITLE
update travis scripts to use scanCode from OW utilities repo.

### DIFF
--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -2,11 +2,10 @@
 set -e
 
 # Build script for Travis-CI.
-
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)
 ROOTDIR="$SCRIPTDIR/../.."
-WHISKDIR="$ROOTDIR/../openwhisk"
+UTIL_DIR="$ROOTDIR/../incubator-openwhisk-utilities"
 
 # run scancode
-cd $WHISKDIR
-tools/build/scanCode.py $ROOTDIR
+cd $UTIL_DIR
+scancode/scanCode.py $ROOTDIR

--- a/tools/travis/setup.sh
+++ b/tools/travis/setup.sh
@@ -5,4 +5,4 @@ HOMEDIR="$SCRIPTDIR/../../../"
 
 # clone OpenWhisk repo. in order to run scanCode.py
 cd $HOMEDIR
-git clone https://github.com/openwhisk/openwhisk.git
+git clone https://github.com/apache/incubator-openwhisk-utilities.git


### PR DESCRIPTION
Use the scanCode.py (and common travis.cfg) from new "incubator-openwhisk-utilities" repo. under Apache (removing old use of "openwhisk" repo. under openwhisk org.).