### PR TITLE
Add the Travis configuration to run integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,32 @@
 # A Travis CI configuration file.
 
-sudo: required
-
 language: go
 
-go:
-  - 1.7
+matrix:
+    include:
+        - os: linux
+          sudo: required
+          go: 1.7
+          services: docker
+        - os: osx
+          go: 1.7
+
+git:
+  depth: 3
 
 before_install:
-- ./tools/travis/setup.sh
+  - pip install --upgrade pip setuptools
+  - ./tools/travis/setup.sh
+
+install:
+  - export DEPLOY_BUILD_READY=false
+  - go get -u github.com/golang/lint/golint
+  - go get -u github.com/stretchr/testify
+  - go get -u github.com/spf13/viper
 
 script:
-- ./tools/travis/build.sh
+  - ./tools/travis/build.sh
+  - export PATH=$PATH:$TRAVIS_BUILD_DIR;
+  - if [ "$TRAVIS_OS_NAME" == "linux" ] ; then
+      ./tools/travis/test_openwhisk.sh;
+    fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# incubator-openwhisk-client-go
+# Openwhisk Client Go
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
+[![Build Status](https://travis-ci.org/apache/incubator-openwhisk-client-go.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-client-go)
 
-`go-whisk` is a Go client library for accessing the IBM Whisk API.
+This project `openwhisk-client-go` is a Go client library to access Openwhisk API.
 
 
 ### Usage

--- a/tools/travis/test_openwhisk.sh
+++ b/tools/travis/test_openwhisk.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -e
+
+export OPENWHISK_HOME="$(dirname "$TRAVIS_BUILD_DIR")/incubator-openwhisk";
+HOMEDIR="$(dirname "$TRAVIS_BUILD_DIR")"
+cd $HOMEDIR
+
+# Clone the OpenWhisk code
+git clone --depth 3 https://github.com/apache/incubator-openwhisk.git
+
+# Clone the OpenWhisk CLI code
+git clone --depth 3 https://github.com/apache/incubator-openwhisk-cli.git
+
+# Build script for Travis-CI.
+WHISKDIR="$HOMEDIR/incubator-openwhisk"
+OPENWHISK_CLI_BUILD_DIR="$HOMEDIR/incubator-openwhisk-cli"
+
+cd $WHISKDIR
+./tools/travis/setup.sh
+
+ANSIBLE_CMD="ansible-playbook -i environments/local -e docker_image_prefix=testing"
+
+cd $WHISKDIR/ansible
+$ANSIBLE_CMD setup.yml
+$ANSIBLE_CMD prereq.yml
+$ANSIBLE_CMD couchdb.yml
+$ANSIBLE_CMD initdb.yml
+$ANSIBLE_CMD apigateway.yml
+
+cd $WHISKDIR
+GRADLE_PROJS_SKIP="-x :core:pythonAction:distDocker  -x :core:python2Action:distDocker -x :core:swift3Action:distDocker -x :core:javaAction:distDocker"
+TERM=dumb ./gradlew distDocker -PdockerImagePrefix=testing $GRADLE_PROJS_SKIP
+
+cd $WHISKDIR/ansible
+$ANSIBLE_CMD wipe.yml
+$ANSIBLE_CMD openwhisk.yml
+
+# Install the dependencies for openwhisk cli and build the binary based on the current changes.
+cd $OPENWHISK_CLI_BUILD_DIR
+go get -d -t ./...
+go build -ldflags "-X main.CLI_BUILD_TIME=`date -u '+%Y-%m-%dT%H:%M:%S%:z'`" -o wsk
+
+# Copy the binary generated into the OPENWHISK_HOME/bin, so that the test cases will run based on it.
+mkdir -p $WHISKDIR/bin
+cp $OPENWHISK_CLI_BUILD_DIR/wsk $WHISKDIR/bin
+
+# Run the test cases under openwhisk to ensure the quality of the binary.
+cd $OPENWHISK_CLI_BUILD_DIR
+./gradlew :tests:test -Dtest.single=Wsk*Tests*
+sleep 30
+./gradlew tests:test -Dtest.single=*ApiGwRoutemgmtActionTests*
+sleep 30
+./gradlew tests:test -Dtest.single=*ApiGwTests*
+sleep 30
+./gradlew tests:test -Dtest.single=*ApiGwEndToEndTests*


### PR DESCRIPTION
This repo will eventually has unit tests and integration tests writen
in Go running against the openwhisk services. However, before this
work item is finished, we need to at least have the existing scala
tests as the goalkeeper to guarentee the code quality of new PRs.
This is the reason why we use this PR as a tentative solution
to fill in the gap of missing test caes. At the same time, we are
working on the test cases for this repo.