### PR TITLE
Support client certificate on cli and nginx (#2427)

### DIFF
--- a/whisk/client.go
+++ b/whisk/client.go
@@ -66,12 +66,14 @@ type Client struct {
 }
 
 type Config struct {
-    Namespace     string // NOTE :: Default is "_"
-    AuthToken     string
-    Host        string
-    BaseURL       *url.URL // NOTE :: Default is "openwhisk.ng.bluemix.net"
-    Version       string
-    Verbose       bool
+    Namespace 	string // NOTE :: Default is "_"
+    Cert        string
+    Key         string
+    AuthToken 	string
+    Host		string
+    BaseURL   	*url.URL // NOTE :: Default is "openwhisk.ng.bluemix.net"
+    Version   	string
+    Verbose   	bool
     Debug       bool     // For detailed tracing
     Insecure    bool
 }
@@ -81,9 +83,18 @@ func NewClient(httpClient *http.Client, config *Config) (*Client, error) {
     // Disable certificate checking in the dev environment if in insecure mode
     if config.Insecure {
         Debug(DbgInfo, "Disabling certificate checking.\n")
-
-        tlsConfig := &tls.Config{
-            InsecureSkipVerify: true,
+        var tlsConfig *tls.Config
+        if config.Cert != "" && config.Key != "" {
+            if cert, err := tls.LoadX509KeyPair(config.Cert, config.Key); err == nil {
+                tlsConfig = &tls.Config{
+                    Certificates: []tls.Certificate{cert},
+                    InsecureSkipVerify: true,
+                }
+            }
+        }else{
+            tlsConfig = &tls.Config{
+                InsecureSkipVerify: true,
+            }
         }
 
         http.DefaultClient.Transport = &http.Transport{


### PR DESCRIPTION
In order to increase the security of auth, it is necessary to add client
certificate on cli and nginx. So user can use wsk -i property set --cert
openwhisk-client-cert.pem --key openwhisk-client-key.pem to pass client
certificate to nginx. If you don't want to use default client certificate
which system provides, you can create your own client certificate instead
of them.