### PR TITLE
Replace the path of wskprops' parent dir with the path of wskprops

### DIFF
--- a/whisk/wskprops.go
+++ b/whisk/wskprops.go
@@ -30,7 +30,7 @@ import (
 
 const (
     OPENWHISK_HOME = "OPENWHISK_HOME"
-    GOPATH = "GOPATH"
+    HOMEPATH = "HOME"
     DEFAULT_LOCAL_CONFIG = ".wskprops"
     OPENWHISK_PROPERTIES = "whisk.properties"
     TEST_AUTH_FILE = "testing.auth"
@@ -48,8 +48,8 @@ const (
     CERT = "CERT"
     APIHOST = "APIHOST"
 
-    DEFAULT_SOURCE = ".wskprops"
-    WSKPROP = ".wskprops"
+    DEFAULT_SOURCE = "wsk props"
+    WSKPROP = "wsk props"
     WHISK_PROPERTY = "whisk.properties"
 )
 
@@ -162,13 +162,13 @@ type PropertiesImp struct {
 func (pi PropertiesImp) GetPropsFromWskprops(path string) *Wskprops {
     dep := GetDefaultWskprops(WSKPROP)
 
-    var configPath string
+    var wskpropsPath string
     if path != "" {
-        configPath = path
+        wskpropsPath = path
     } else {
-        configPath = pi.OsPackage.Getenv(GOPATH, "")
+        wskpropsPath = pi.OsPackage.Getenv(HOMEPATH, "") + "/" + DEFAULT_LOCAL_CONFIG
     }
-    results, err := ReadProps(configPath + "/" + DEFAULT_LOCAL_CONFIG)
+    results, err := ReadProps(wskpropsPath)
 
     if err == nil {
 

--- a/whisk/wskprops_test.go
+++ b/whisk/wskprops_test.go
@@ -1,4 +1,4 @@
-// +build unit
+//// +build unit
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -239,7 +239,7 @@ func TestGetPropsFromWskprops(t *testing.T) {
 
     fakeOSPackage := FakeOSPackage{
         StoredValues: map[string]string {
-            GOPATH: getCurrentDir(),
+            HOMEPATH: getCurrentDir(),
         },
     }
     pi := PropertiesImp{
@@ -257,7 +257,7 @@ func TestGetPropsFromWskprops(t *testing.T) {
     assert.Equal(t, EXPECTED_CERT, dep.Cert)
     assert.Equal(t, WSKPROP, dep.Source)
 
-    path := getCurrentDir()
+    path := getCurrentDir() + "/" + DEFAULT_LOCAL_CONFIG
     dep = pi.GetPropsFromWskprops(path)
     assert.Equal(t, DEFAULT_NAMESPACE, dep.Namespace)
     assert.Equal(t, EXPECTED_TEST_AUTH_KEY, dep.AuthKey)


### PR DESCRIPTION
We need to search for .wskprops under HOME dir instead of GOPATH. In
addition, we support the input of the full path of the wskprops file
instead of the path of the parent dir.