### PR TITLE
Use a HTTP transport based on the DefaultTransport to pick up proxy support

### DIFF
--- a/whisk/client.go
+++ b/whisk/client.go
@@ -196,9 +196,11 @@ func (c *Client) LoadX509KeyPair() error {
 		}
 	}
 
-	c.client.Transport = &http.Transport{
-		TLSClientConfig: tlsConfig,
-	}
+	// Use the defaultTransport as the transport basis to maintain proxy support
+	// Make a copy of the defaultTransport so that the original defaultTransport is left alone
+	defaultTransportCopy := *(http.DefaultTransport.(*http.Transport))
+	defaultTransportCopy.TLSClientConfig = tlsConfig
+	c.client.Transport = &defaultTransportCopy
 
 	return nil
 }

--- a/whisk/wskprops_test.go
+++ b/whisk/wskprops_test.go
@@ -1,4 +1,4 @@
-//// +build unit
+// +build unit
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more


### PR DESCRIPTION
Fixes #54 