### PR TITLE
Parse new 'rules' field in 'trigger get' response

### DIFF
--- a/whisk/trigger.go
+++ b/whisk/trigger.go
@@ -39,6 +39,7 @@ type Trigger struct {
 	Parameters   KeyValueArr `json:"parameters,omitempty"`
 	Limits       *Limits     `json:"limits,omitempty"`
 	Publish      *bool       `json:"publish,omitempty"`
+    Rules        map[string]interface{} `json:"rules,omitempty"`
 }
 
 type TriggerListOptions struct {

--- a/whisk/trigger.go
+++ b/whisk/trigger.go
@@ -27,7 +27,7 @@ import (
 )
 
 type TriggerService struct {
-	client *Client
+	client ClientInterface
 }
 
 type Trigger struct {

--- a/whisk/trigger.go
+++ b/whisk/trigger.go
@@ -31,15 +31,15 @@ type TriggerService struct {
 }
 
 type Trigger struct {
-	Namespace    string      `json:"namespace,omitempty"`
-	Name         string      `json:"name,omityempty"`
-	Version      string      `json:"version,omitempty"`
-	ActivationId string      `json:"activationId,omitempty"`
-	Annotations  KeyValueArr `json:"annotations,omitempty"`
-	Parameters   KeyValueArr `json:"parameters,omitempty"`
-	Limits       *Limits     `json:"limits,omitempty"`
-	Publish      *bool       `json:"publish,omitempty"`
-    Rules        map[string]interface{} `json:"rules,omitempty"`
+	Namespace    string                 `json:"namespace,omitempty"`
+	Name         string                 `json:"name,omityempty"`
+	Version      string                 `json:"version,omitempty"`
+	ActivationId string                 `json:"activationId,omitempty"`
+	Annotations  KeyValueArr            `json:"annotations,omitempty"`
+	Parameters   KeyValueArr            `json:"parameters,omitempty"`
+	Limits       *Limits                `json:"limits,omitempty"`
+	Publish      *bool                  `json:"publish,omitempty"`
+	Rules        map[string]interface{} `json:"rules,omitempty"`
 }
 
 type TriggerListOptions struct {

--- a/whisk/trigger_test.go
+++ b/whisk/trigger_test.go
@@ -1,0 +1,131 @@
+// +build unit
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+const (
+	TRIGGER_GET_NO_RULES = `{
+                "namespace": "test@openwhisk_dev",
+                "name": "testTrigger",
+                "publish": false,
+                "version": "0.0.1",
+                "limits": {}
+        }`
+
+	TRIGGER_GET_WITH_RULES = `{
+                "namespace": "test@openwhisk_dev",
+                "name": "testTrigger",
+                "publish": false,
+                "version": "0.0.1",
+                "limits": {},
+                "rules": {
+                        "guest/inactiverule": {
+                                "action": {
+                                        "name": "web-echo-env",
+                                        "path": "guest"
+                                },
+                        "status": "inactive"
+                        }
+                }
+        }`
+)
+
+type TriggerResponse struct {
+	Body string
+}
+
+type TriggerRequest struct {
+	Method string
+	URL    string
+}
+
+var triggerResponse = &TriggerResponse{}
+var triggerRequest = &TriggerRequest{}
+
+type MockTriggerClient struct{}
+
+func (c *MockTriggerClient) NewRequestUrl(method string, urlRelResource *url.URL, body interface{}, includeNamespaceInUrl bool, appendOpenWhiskPath bool, encodeBodyAs string, useAuthentication bool) (*http.Request, error) {
+	return &http.Request{}, nil
+}
+
+func (c *MockTriggerClient) NewRequest(method, urlStr string, body interface{}, includeNamespaceInUrl bool) (*http.Request, error) {
+	triggerRequest.Method = method
+	triggerRequest.URL = urlStr
+
+	request, err := http.NewRequest(method, urlStr, nil)
+	if err != nil {
+		fmt.Printf("http.NewRequest() failure: %s\n", err)
+		return &http.Request{}, err
+	}
+
+	return request, nil
+}
+
+func (c *MockTriggerClient) Do(req *http.Request, v interface{}, ExitWithErrorOnTimeout bool, secretToObfuscate ...ObfuscateSet) (*http.Response, error) {
+	var reader = strings.NewReader(triggerResponse.Body)
+
+	dc := json.NewDecoder(reader)
+	dc.UseNumber()
+	err := dc.Decode(v)
+
+	if err != nil {
+		fmt.Printf("json decode failure: %s\n", err)
+		return nil, err
+	}
+
+	resp := &http.Response{
+		StatusCode: 200,
+		Body:       ioutil.NopCloser(reader),
+	}
+
+	return resp, nil
+}
+
+func TestTriggerGet(t *testing.T) {
+	assert := assert.New(t)
+	mockClient := &MockTriggerClient{}
+	triggerService := &TriggerService{client: mockClient}
+	var nilMap map[string]interface{}
+
+	triggerResponse.Body = TRIGGER_GET_NO_RULES
+	trigger, _, _ := triggerService.Get("testTrigger")
+	assert.Equal("GET", triggerRequest.Method)
+	assert.Equal("triggers/testTrigger", triggerRequest.URL)
+	assert.Equal(nilMap, trigger.Rules)
+
+	triggerResponse.Body = TRIGGER_GET_WITH_RULES
+	var expectedTrigger map[string]interface{}
+	json.Unmarshal([]byte(triggerResponse.Body), &expectedTrigger)
+	expectedRules, _ := expectedTrigger["rules"]
+	trigger, _, _ = triggerService.Get("testTrigger")
+	assert.Equal("GET", triggerRequest.Method)
+	assert.Equal("triggers/testTrigger", triggerRequest.URL)
+	assert.Equal(expectedRules, trigger.Rules)
+}


### PR DESCRIPTION
- Update trigger struct to optionally include a `rules` field
- Add a test to validate `rules` are returned 