### PR TITLE
Add support for APIs defined with web actions having the require-whisk-auth annotation

### DIFF
--- a/whisk/api.go
+++ b/whisk/api.go
@@ -101,12 +101,12 @@ type ApiParameter struct {
 }
 
 type ApiAction struct {
-	Name          string `json:"name,omitempty"`
-	Namespace     string `json:"namespace,omitempty"`
-	BackendMethod string `json:"backendMethod,omitempty"`
-	BackendUrl    string `json:"backendUrl,omitempty"`
-	Auth          string `json:"authkey,omitempty"`
-	SecureKey     string `json:"secureKey,omitempty"`
+	Name          string      `json:"name,omitempty"`
+	Namespace     string      `json:"namespace,omitempty"`
+	BackendMethod string      `json:"backendMethod,omitempty"`
+	BackendUrl    string      `json:"backendUrl,omitempty"`
+	Auth          string      `json:"authkey,omitempty"`
+	SecureKey     interface{} `json:"secureKey,omitempty"`
 }
 
 type ApiOptions struct {

--- a/whisk/api.go
+++ b/whisk/api.go
@@ -106,6 +106,7 @@ type ApiAction struct {
 	BackendMethod string `json:"backendMethod,omitempty"`
 	BackendUrl    string `json:"backendUrl,omitempty"`
 	Auth          string `json:"authkey,omitempty"`
+    SecureKey     string `json:"secureKey,omitempty"`
 }
 
 type ApiOptions struct {

--- a/whisk/api.go
+++ b/whisk/api.go
@@ -106,7 +106,7 @@ type ApiAction struct {
 	BackendMethod string `json:"backendMethod,omitempty"`
 	BackendUrl    string `json:"backendUrl,omitempty"`
 	Auth          string `json:"authkey,omitempty"`
-    SecureKey     string `json:"secureKey,omitempty"`
+	SecureKey     string `json:"secureKey,omitempty"`
 }
 
 type ApiOptions struct {

--- a/whisk/keyvaluearr_test.go
+++ b/whisk/keyvaluearr_test.go
@@ -20,23 +20,23 @@
 package whisk
 
 import (
-	"testing"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestKeyValueArrReplaceOrAdd(t *testing.T) {
-    kvArr := make(KeyValueArr, 3)
-    kvArr[0] = KeyValue{"key0", "value0"}
-    kvArr[1] = KeyValue{"key1", "value1"}
-    kvArr[2] = KeyValue{"key2", "value2"}
+	kvArr := make(KeyValueArr, 3)
+	kvArr[0] = KeyValue{"key0", "value0"}
+	kvArr[1] = KeyValue{"key1", "value1"}
+	kvArr[2] = KeyValue{"key2", "value2"}
 
-    kvNew := &KeyValue{"keyAdd", "valueAdd"}
-    kvArrNew := kvArr.AddOrReplace(kvNew)
-    assert.Equal(t, len(kvArrNew), 4)
-    assert.Equal(t, kvArrNew.GetValue(kvNew.Key), kvNew.Value)
+	kvNew := &KeyValue{"keyAdd", "valueAdd"}
+	kvArrNew := kvArr.AddOrReplace(kvNew)
+	assert.Equal(t, len(kvArrNew), 4)
+	assert.Equal(t, kvArrNew.GetValue(kvNew.Key), kvNew.Value)
 
-    kvAdd := &KeyValue{"key3", "valueReplace"}
-    kvArrNew = kvArr.AddOrReplace(kvAdd)
-    assert.Equal(t, len(kvArrNew), 4)
-    assert.Equal(t, kvArrNew.GetValue(kvAdd.Key), kvAdd.Value)
+	kvAdd := &KeyValue{"key3", "valueReplace"}
+	kvArrNew = kvArr.AddOrReplace(kvAdd)
+	assert.Equal(t, len(kvArrNew), 4)
+	assert.Equal(t, kvArrNew.GetValue(kvAdd.Key), kvAdd.Value)
 }

--- a/whisk/keyvaluearr_test.go
+++ b/whisk/keyvaluearr_test.go
@@ -1,0 +1,42 @@
+// +build unit
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeyValueArrReplaceOrAdd(t *testing.T) {
+    kvArr := make(KeyValueArr, 3)
+    kvArr[0] = KeyValue{"key0", "value0"}
+    kvArr[1] = KeyValue{"key1", "value1"}
+    kvArr[2] = KeyValue{"key2", "value2"}
+
+    kvNew := &KeyValue{"keyAdd", "valueAdd"}
+    kvArrNew := kvArr.AddOrReplace(kvNew)
+    assert.Equal(t, len(kvArrNew), 4)
+    assert.Equal(t, kvArrNew.GetValue(kvNew.Key), kvNew.Value)
+
+    kvAdd := &KeyValue{"key3", "valueReplace"}
+    kvArrNew = kvArr.AddOrReplace(kvAdd)
+    assert.Equal(t, len(kvArrNew), 4)
+    assert.Equal(t, kvArrNew.GetValue(kvAdd.Key), kvAdd.Value)
+}

--- a/whisk/shared.go
+++ b/whisk/shared.go
@@ -63,17 +63,17 @@ func (keyValueArr KeyValueArr) FindKeyValue(key string) int {
  * Returns a new key value array with the update
  */
 func (keyValueArr KeyValueArr) AddOrReplace(kv *KeyValue) KeyValueArr {
-    var replaced = false
-    for i := 0; i < len(keyValueArr); i++ {
-        if strings.ToLower(keyValueArr[i].Key) == strings.ToLower(kv.Key) {
-            keyValueArr[i].Value = kv.Value
-            replaced = true
-        }
-    }
-    if !replaced {
-        return append(keyValueArr, *kv)
-    }
-    return keyValueArr
+	var replaced = false
+	for i := 0; i < len(keyValueArr); i++ {
+		if strings.ToLower(keyValueArr[i].Key) == strings.ToLower(kv.Key) {
+			keyValueArr[i].Value = kv.Value
+			replaced = true
+		}
+	}
+	if !replaced {
+		return append(keyValueArr, *kv)
+	}
+	return keyValueArr
 }
 
 /*

--- a/whisk/shared.go
+++ b/whisk/shared.go
@@ -57,6 +57,26 @@ func (keyValueArr KeyValueArr) FindKeyValue(key string) int {
 }
 
 /*
+ * Adds the specified KeyValue to the key value array.  If the KeyValue's key
+ * is already in the array, that entry is updated with the KeyValue's value.
+ *
+ * Returns a new key value array with the update
+ */
+func (keyValueArr KeyValueArr) AddOrReplace(kv *KeyValue) KeyValueArr {
+    var replaced = false
+    for i := 0; i < len(keyValueArr); i++ {
+        if strings.ToLower(keyValueArr[i].Key) == strings.ToLower(kv.Key) {
+            keyValueArr[i].Value = kv.Value
+            replaced = true
+        }
+    }
+    if !replaced {
+        return append(keyValueArr, *kv)
+    }
+    return keyValueArr
+}
+
+/*
 Appends items from appKeyValueArr to keyValueArr if the appKeyValueArr item does not exist in keyValueArr.
 */
 func (keyValueArr KeyValueArr) AppendKeyValueArr(appKeyValueArr KeyValueArr) KeyValueArr {


### PR DESCRIPTION
Add Go SDK support for https://github.com/apache/incubator-openwhisk/pull/3388

Additional changes to follow
- Update CLI to leverage this SDK update (incubator-openwhisk-cli repo)
- Swagger generation updates in the apimgmt createApi action (incubator-openwhisk repo)