### PR TITLE
adding start library for easy implementation of Go actions

### DIFF
--- a/whisk/start.go
+++ b/whisk/start.go
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package whisk
 
 import (

--- a/whisk/start.go
+++ b/whisk/start.go
@@ -1,0 +1,62 @@
+package whisk
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+)
+
+// ActionFunction is the signature of an action in OpenWhisk
+type ActionFunction func(event json.RawMessage) (json.RawMessage, error)
+
+// actual implementation of a read-eval-print-loop
+func repl(fn ActionFunction, in io.Reader, out io.Writer) {
+	// read loop
+	reader := bufio.NewReader(in)
+	for {
+		event, err := reader.ReadBytes('\n')
+		if err != nil {
+			break
+		}
+		result, err := fn(event)
+		if err != nil {
+			fmt.Fprintf(out, "{ error: %q}\n", err.Error())
+			continue
+		}
+		fmt.Fprintln(out, string(result))
+	}
+}
+
+// Start will start a loop reading in stdin and outputting in fd3
+// This is expected to be uses for implementing Go actions
+func Start(fn ActionFunction) {
+	out := os.NewFile(3, "pipe")
+	defer out.Close()
+	repl(fn, os.Stdin, out)
+}
+
+// StartWithArgs will execute the function for each arg
+// If there are no args it will start a read-write loop on the function
+// Expected to be used as starting point for implementing Go Actions
+// as whisk.StartWithArgs(function, os.Args[:1])
+// if args are 2 (command and one parameter) it will invoke the function once
+// otherwise it will stat the function in a read-write loop
+func StartWithArgs(action ActionFunction, args []string) {
+	// handle command line argument
+	if len(args) > 0 {
+		for _, arg := range args {
+			log.Println(arg)
+			result, err := action([]byte(arg))
+			if err == nil {
+				fmt.Println(string(result))
+			} else {
+				log.Println(err)
+			}
+		}
+		return
+	}
+	Start(action)
+}

--- a/whisk/start_test.go
+++ b/whisk/start_test.go
@@ -1,0 +1,39 @@
+package whisk
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+func hello(event json.RawMessage) (json.RawMessage, error) {
+	var obj map[string]interface{}
+	json.Unmarshal(event, &obj)
+	name, ok := obj["name"].(string)
+	if !ok {
+		name = "Stranger"
+	}
+	fmt.Printf("name=%s\n", name)
+	msg := map[string]string{"message": ("Hello, " + name + "!")}
+	return json.Marshal(msg)
+}
+
+func Example_repl() {
+	in := bytes.NewBufferString("{\"name\":\"Mike\"}\nerr\n")
+	repl(hello, in, os.Stdout)
+	// Output:
+	// name=Mike
+	// {"message":"Hello, Mike!"}
+	// name=Stranger
+	// {"message":"Hello, Stranger!"}
+}
+
+func ExampleStart() {
+	StartWithArgs(hello, []string{"{\"name\":\"Mike\"}", "err"})
+	// Output:
+	// name=Mike
+	// {"message":"Hello, Mike!"}
+	// name=Stranger
+	// {"message":"Hello, Stranger!"}
+}

--- a/whisk/start_test.go
+++ b/whisk/start_test.go
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package whisk
 
 import (


### PR DESCRIPTION
there is only one file, start.go providing the whisk.Start and whisk.StartWithArgs functions.

Those are helpers to implement Golang based actions as provided by the openwhisk-runtime-go

Basically they let you to define an action as

func action(event json.RawMessage) (json.RawMessage, error)

and create a main as

func main() { whisk.Start(action) }

or

func main(args []string) { whisk.StartWithArgs(action, args[1:]) } 

the last one is a useful helper to try the function from the command line and make it compatible with the current docker skeleton.