### PR TITLE
Add Concurrency to Limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Godeps/_workspace
 .idea
+*.iml

--- a/whisk/shared.go
+++ b/whisk/shared.go
@@ -94,7 +94,8 @@ type Annotations []map[string]interface{}
 type Parameters *json.RawMessage
 
 type Limits struct {
-	Timeout *int `json:"timeout,omitempty"`
-	Memory  *int `json:"memory,omitempty"`
-	Logsize *int `json:"logs,omitempty"`
+	Timeout     *int `json:"timeout,omitempty"`
+	Memory      *int `json:"memory,omitempty"`
+	Logsize     *int `json:"logs,omitempty"`
+	Concurrency *int `json:"concurrency,omitempty"`
 }


### PR DESCRIPTION
Adds a Concurrency field to Limits to specify the concurrency limit for the action.

Blocked by:
* https://github.com/apache/incubator-openwhisk/pull/2795