### PR TITLE
Replace trigger service type with interface

### DIFF
--- a/whisk/client.go
+++ b/whisk/client.go
@@ -58,13 +58,21 @@ type ClientInterface interface {
 	Do(req *http.Request, v interface{}, ExitWithErrorOnTimeout bool, secretToObfuscate ...ObfuscateSet) (*http.Response, error)
 }
 
+type TriggerServiceInterface interface {
+	List(options *TriggerListOptions) ([]Trigger, *http.Response, error)
+	Insert(trigger *Trigger, overwrite bool) (*Trigger, *http.Response, error)
+	Get(triggerName string) (*Trigger, *http.Response, error)
+	Delete(triggerName string) (*Trigger, *http.Response, error)
+	Fire(triggerName string, payload interface{}) (*Trigger, *http.Response, error)
+}
+
 type Client struct {
 	client *http.Client
 	*Config
 	Transport *http.Transport
 
 	Sdks        *SdkService
-	Triggers    *TriggerService
+	Triggers    TriggerServiceInterface
 	Actions     *ActionService
 	Rules       *RuleService
 	Activations *ActivationService


### PR DESCRIPTION
Hi openwhiskers!

as per description, I'd like to replace the consumption of the trigger type with an interface. 
This change will enable https://github.com/apache/incubator-openwhisk-cli/pull/353 to run the unit tests for Trigger creation and update. 

Could someone have a look? 
Could be I'm overlooking something due to lack of the codebase knowledge of this repo. 

regards,
Vadim