### PR TITLE
allow additional headers to override auth header val

### DIFF
--- a/whisk/client.go
+++ b/whisk/client.go
@@ -301,7 +301,13 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}, includeName
 }
 
 func (c *Client) addAuthHeader(req *http.Request, authRequired bool) error {
-	if c.Config.AuthToken != "" {
+	// Allow for authorization override via Additional Headers
+	additionalHeaderAuth := c.Config.AdditionalHeaders.Get("Authorization")
+	if additionalHeaderAuth != "" {
+		req.Header.Add("Authorization", fmt.Sprintf(additionalHeaderAuth))
+		Debug(DbgInfo, "Adding basic auth header; using additional header auth\n")
+		c.Config.AdditionalHeaders.Del("Authorization") // Must delete the additional header to avoid conflicts
+	} else if c.Config.AuthToken != "" {
 		encodedAuthToken := base64.StdEncoding.EncodeToString([]byte(c.Config.AuthToken))
 		req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedAuthToken))
 		Debug(DbgInfo, "Adding basic auth header; using authkey\n")

--- a/whisk/client.go
+++ b/whisk/client.go
@@ -303,12 +303,12 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}, includeName
 func (c *Client) addAuthHeader(req *http.Request, authRequired bool) error {
 	// Allow for authorization override via Additional Headers
 	authHeaderValue := c.Config.AdditionalHeaders.Get("Authorization")
-	if authHeaderValue == "" && c.Config.AuthToken != "" {
+	if authHeaderValue != "" {
+		Debug(DbgInfo, "Using additional header authorization\n")
+	} else if c.Config.AuthToken != "" {
 		encodedAuthToken := base64.StdEncoding.EncodeToString([]byte(c.Config.AuthToken))
 		req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedAuthToken))
 		Debug(DbgInfo, "Adding basic auth header; using authkey\n")
-	} else if authHeaderValue != "" {
-		Debug(DbgInfo, "Using additional header authorization\n")
 	} else {
 		if authRequired {
 			Debug(DbgError, "The required authorization key is not configured - neither set as a property nor set via the --auth CLI argument\n")

--- a/whisk/client.go
+++ b/whisk/client.go
@@ -302,15 +302,15 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}, includeName
 
 func (c *Client) addAuthHeader(req *http.Request, authRequired bool) error {
 	// Allow for authorization override via Additional Headers
-	additionalHeaderAuth := c.Config.AdditionalHeaders.Get("Authorization")
-	if additionalHeaderAuth != "" {
-		req.Header.Add("Authorization", fmt.Sprintf(additionalHeaderAuth))
-		Debug(DbgInfo, "Adding basic auth header; using additional header auth\n")
-		c.Config.AdditionalHeaders.Del("Authorization") // Must delete the additional header to avoid conflicts
-	} else if c.Config.AuthToken != "" {
+	authHeaderValue := c.Config.AdditionalHeaders.Get("Authorization")
+	c.Config.AdditionalHeaders.Del("Authorization") // Must delete the additional header to avoid conflicts
+	if authHeaderValue == "" && c.Config.AuthToken != "" {
 		encodedAuthToken := base64.StdEncoding.EncodeToString([]byte(c.Config.AuthToken))
 		req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedAuthToken))
 		Debug(DbgInfo, "Adding basic auth header; using authkey\n")
+	} else if authHeaderValue != "" {
+		req.Header.Add("Authorization", fmt.Sprintf(authHeaderValue))
+		Debug(DbgInfo, "Adding basic auth header; using additional header auth\n")
 	} else {
 		if authRequired {
 			Debug(DbgError, "The required authorization key is not configured - neither set as a property nor set via the --auth CLI argument\n")

--- a/whisk/client.go
+++ b/whisk/client.go
@@ -303,14 +303,12 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}, includeName
 func (c *Client) addAuthHeader(req *http.Request, authRequired bool) error {
 	// Allow for authorization override via Additional Headers
 	authHeaderValue := c.Config.AdditionalHeaders.Get("Authorization")
-	c.Config.AdditionalHeaders.Del("Authorization") // Must delete the additional header to avoid conflicts
 	if authHeaderValue == "" && c.Config.AuthToken != "" {
 		encodedAuthToken := base64.StdEncoding.EncodeToString([]byte(c.Config.AuthToken))
 		req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedAuthToken))
 		Debug(DbgInfo, "Adding basic auth header; using authkey\n")
 	} else if authHeaderValue != "" {
-		req.Header.Add("Authorization", fmt.Sprintf(authHeaderValue))
-		Debug(DbgInfo, "Adding basic auth header; using additional header auth\n")
+		Debug(DbgInfo, "Using additional header authorization\n")
 	} else {
 		if authRequired {
 			Debug(DbgError, "The required authorization key is not configured - neither set as a property nor set via the --auth CLI argument\n")


### PR DESCRIPTION
I'd like to provide a way to override the existing auth header for client requests using additional headers. Currently, if attempting to add an `"authorization"` header to the `AdditionalHeaders` var the headers get mashed together causing conflicts. This PR rectifies that issue.