### PR TITLE
golint package path update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
 
 install:
   - export DEPLOY_BUILD_READY=false
-  - go get -u github.com/golang/lint/golint
+  - go get -u golang.org/x/lint/golint
   - go get -u github.com/stretchr/testify
 
 script:


### PR DESCRIPTION
fixes travis failure related to change in golint package path enforcement, like
```
$ go get -u github.com/golang/lint/golint
package github.com/golang/lint/golint: code in directory /home/travis/gopath/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"
```