### PR TITLE
Update Go Version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
         - os: linux
           sudo: required
           group: deprecated-2017Q3
-          go: 1.8
+          go: 1.9.3
           services: docker
 
 git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
         - os: linux
           sudo: required
           group: deprecated-2017Q3
-          go: 1.9.3
+          go: "1.9.3"
           services: docker
 
 git:

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
 	"ImportPath": "github.com/apache/incubator-openwhisk-client-go",
-	"GoVersion": "go1.8",
+	"GoVersion": "go1.9.3",
 	"Deps": []
 }


### PR DESCRIPTION
Travis is failing due to golint as shown below. It appears Go 1.8 is no longer supported (https://github.com/golang/go/issues/28291).

```
$ go get -u golang.org/x/lint/golint
# golang.org/x/tools/go/internal/gcimporter
../../../golang.org/x/tools/go/internal/gcimporter/bexport.go:212: obj.IsAlias undefined (type *types.TypeName has no field or method IsAlias)
The command "go get -u golang.org/x/lint/golint" failed and exited with 2 during .
```

