### PR TITLE
as godep is deprecated, move to govendor 

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,5 +1,0 @@
-{
-	"ImportPath": "github.com/apache/incubator-openwhisk-client-go",
-	"GoVersion": "go1.9.3",
-	"Deps": []
-}

--- a/Godeps/Readme
+++ b/Godeps/Readme
@@ -1,5 +1,0 @@
-This directory tree is generated automatically by godep.
-
-Please do not edit.
-
-See https://github.com/tools/godep for more information.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This project `openwhisk-client-go` is a Go client library to access Openwhisk AP
 
 You need to install the following package in order to run this Go client library:
 - [Go](https://golang.org/doc/install)
+- [govendor](https://github.com/kardianos/govendor)
 
 Make sure you select the package that fits your local environment, and [set the GOPATH environment variable](https://github.com/golang/go/wiki/SettingGOPATH).
 
@@ -45,6 +46,7 @@ Open a terminal, and run the following commands to run the unit tests:
 
 ```
 $ cd $GOPATH/src/github.com/apache/incubator-openwhisk-client-go
+$ govendor sync
 $ go test -v ./... -tags=unit
 ```
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,0 +1,25 @@
+{
+	"comment": "",
+	"ignore": "test",
+	"package": [
+		{
+			"checksumSHA1": "CSPbwbyzqA6sfORicn4HFtIhF/c=",
+			"path": "github.com/davecgh/go-spew/spew",
+			"revision": "d8f796af33cc11cb798c1aaeb27a4ebc5099927d",
+			"revisionTime": "2018-08-30T19:11:22Z"
+		},
+		{
+			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",
+			"path": "github.com/pmezard/go-difflib/difflib",
+			"revision": "5d4384ee4fb2527b0a1256a821ebfc92f91efefc",
+			"revisionTime": "2018-12-26T10:54:42Z"
+		},
+		{
+			"checksumSHA1": "qTNfPVU4Tz/JDMcSeL+k9HX2cV8=",
+			"path": "github.com/stretchr/testify/assert",
+			"revision": "363ebb24d041ccea8068222281c2e963e997b9dc",
+			"revisionTime": "2019-01-09T08:30:14Z"
+		}
+	],
+	"rootPath": "github.com/apache/incubator-openwhisk-client-go"
+}


### PR DESCRIPTION
as https://github.com/apache/incubator-openwhisk-cli is already using it.