### PR TITLE
Added extra columns to activation records summary rows

### DIFF
--- a/whisk/activation.go
+++ b/whisk/activation.go
@@ -20,6 +20,7 @@ package whisk
 import (
 	"errors"
 	"fmt"
+	"time"
 	"github.com/apache/incubator-openwhisk-client-go/wski18n"
 	"net/http"
 	"net/url"
@@ -39,7 +40,8 @@ type Activation struct {
 	Start        int64  `json:"start"`    // When action started (in milliseconds since January 1, 1970 UTC)
 	End          int64  `json:"end"`      // Since a 0 is a valid value from server, don't omit
 	Duration     int64  `json:"duration"` // Only available for actions
-	Response     `json:"response"`
+	StatusCode   uint8  `json:"statusCode"`
+	Response            `json:"response"`
 	Logs         []string    `json:"logs"`
 	Annotations  KeyValueArr `json:"annotations"`
 	Publish      *bool       `json:"publish,omitempty"`
@@ -70,6 +72,9 @@ type Log struct {
 	Time   string `json:"time,omitempty"`
 }
 
+// Status codes to descriptions
+var statusCodes = []string{"success", "application error", "developer error", "internal error"}
+
 // Compare(sortable) compares activation to sortable for the purpose of sorting.
 // REQUIRED: sortable must also be of type Activation.
 // ***Method of type Sortable***
@@ -80,14 +85,58 @@ func (activation Activation) Compare(sortable Sortable) bool {
 
 // ToHeaderString() returns the header for a list of activations
 func (activation Activation) ToHeaderString() string {
-	return fmt.Sprintf("%s\n", "activations")
+	return fmt.Sprintf("%-19s %-32s %-20s %-6s%-10s %-17s %-100s\n", "Datetime", "Activation ID", "Kind", "Start", "Duration", "Status", "Entity")
+}
+
+// TruncateStr() returns the string, truncated with ...in the middle if it exceeds the specified length
+func TruncateStr(str string, maxlen int) string {
+	if (len(str) <= maxlen) {
+	  return str
+	} else {
+	  mid := maxlen / 2
+	  upp := len(str) - mid + 3
+	  if (maxlen%2 != 0) {
+		  mid++
+	  }
+	  return str[0:mid] + "..." + str[upp:]
+	}
 }
 
 // ToSummaryRowString() returns a compound string of required parameters for printing
 //   from CLI command `wsk activation list`.
 // ***Method of type Sortable***
 func (activation Activation) ToSummaryRowString() string {
-	return fmt.Sprintf("%s %-20s\n", activation.ActivationID, activation.Name)
+	s := time.Unix(0, activation.Start * 1000000)
+	e := time.Unix(0, activation.End   * 1000000)
+
+	var duration = e.Sub(s)
+	var kind     interface{} = activation.Annotations.GetValue("kind")
+	var initTime interface{} = activation.Annotations.GetValue("initTime")
+	var status   = statusCodes[0]; // assume success
+	var start    = "warm"          // assume warm
+
+	if activation.Duration == 0 {
+		duration = s.Sub(s)
+	}
+	if kind == nil {
+		kind = "unknown"
+	}
+	if activation.StatusCode > 0 && activation.StatusCode <= 3 {
+		status = statusCodes[activation.StatusCode];
+	}
+	if initTime != nil {
+		start = "cold"
+	}
+
+	return fmt.Sprintf(
+		"%d-%02d-%02d %02d:%02d:%02d %-32s %-20s %-5s %-10v %-17s %-100s\n",
+		s.Year(), s.Month(), s.Day(), s.Hour(), s.Minute(), s.Second(),
+		activation.ActivationID,
+		TruncateStr(kind.(string), 20),
+		start,
+		duration,
+		status,
+		TruncateStr(activation.Namespace, 30) + "/" + TruncateStr(activation.Name, 50) + ":" + TruncateStr(activation.Version, 20))
 }
 
 func (s *ActivationService) List(options *ActivationListOptions) ([]Activation, *http.Response, error) {
@@ -122,7 +171,6 @@ func (s *ActivationService) List(options *ActivationListOptions) ([]Activation, 
 	}
 
 	return activations, resp, nil
-
 }
 
 func (s *ActivationService) Get(activationID string) (*Activation, *http.Response, error) {
@@ -211,5 +259,4 @@ func (s *ActivationService) Result(activationID string) (*Response, *http.Respon
 	}
 
 	return r, resp, nil
-
 }

--- a/whisk/activation.go
+++ b/whisk/activation.go
@@ -20,10 +20,10 @@ package whisk
 import (
 	"errors"
 	"fmt"
-	"time"
 	"github.com/apache/incubator-openwhisk-client-go/wski18n"
 	"net/http"
 	"net/url"
+	"time"
 )
 
 type ActivationService struct {
@@ -41,7 +41,7 @@ type Activation struct {
 	End          int64  `json:"end"`      // Since a 0 is a valid value from server, don't omit
 	Duration     int64  `json:"duration"` // Only available for actions
 	StatusCode   uint8  `json:"statusCode"`
-	Response            `json:"response"`
+	Response     `json:"response"`
 	Logs         []string    `json:"logs"`
 	Annotations  KeyValueArr `json:"annotations"`
 	Publish      *bool       `json:"publish,omitempty"`
@@ -90,15 +90,15 @@ func (activation Activation) ToHeaderString() string {
 
 // TruncateStr() returns the string, truncated with ...in the middle if it exceeds the specified length
 func TruncateStr(str string, maxlen int) string {
-	if (len(str) <= maxlen) {
-	  return str
+	if len(str) <= maxlen {
+		return str
 	} else {
-	  mid := maxlen / 2
-	  upp := len(str) - mid + 3
-	  if (maxlen%2 != 0) {
-		  mid++
-	  }
-	  return str[0:mid] + "..." + str[upp:]
+		mid := maxlen / 2
+		upp := len(str) - mid + 3
+		if maxlen%2 != 0 {
+			mid++
+		}
+		return str[0:mid] + "..." + str[upp:]
 	}
 }
 
@@ -106,14 +106,14 @@ func TruncateStr(str string, maxlen int) string {
 //   from CLI command `wsk activation list`.
 // ***Method of type Sortable***
 func (activation Activation) ToSummaryRowString() string {
-	s := time.Unix(0, activation.Start * 1000000)
-	e := time.Unix(0, activation.End   * 1000000)
+	s := time.Unix(0, activation.Start*1000000)
+	e := time.Unix(0, activation.End*1000000)
 
 	var duration = e.Sub(s)
-	var kind     interface{} = activation.Annotations.GetValue("kind")
+	var kind interface{} = activation.Annotations.GetValue("kind")
 	var initTime interface{} = activation.Annotations.GetValue("initTime")
-	var status   = statusCodes[0]; // assume success
-	var start    = "warm"          // assume warm
+	var status = statusCodes[0] // assume success
+	var start = "warm"          // assume warm
 
 	if activation.Duration == 0 {
 		duration = s.Sub(s)
@@ -122,7 +122,7 @@ func (activation Activation) ToSummaryRowString() string {
 		kind = "unknown"
 	}
 	if activation.StatusCode > 0 && activation.StatusCode <= 3 {
-		status = statusCodes[activation.StatusCode];
+		status = statusCodes[activation.StatusCode]
 	}
 	if initTime != nil {
 		start = "cold"
@@ -136,7 +136,7 @@ func (activation Activation) ToSummaryRowString() string {
 		start,
 		duration,
 		status,
-		TruncateStr(activation.Namespace, 30) + "/" + TruncateStr(activation.Name, 50) + ":" + TruncateStr(activation.Version, 20))
+		TruncateStr(activation.Namespace, 30)+"/"+TruncateStr(activation.Name, 50)+":"+TruncateStr(activation.Version, 20))
 }
 
 func (s *ActivationService) List(options *ActivationListOptions) ([]Activation, *http.Response, error) {


### PR DESCRIPTION
## Description
Added extra columns for output from 'wsk activation list command'. The output now looks as indicated by the screenshot below.
![screenshot from 2019-02-19 20-57-23](https://user-images.githubusercontent.com/8848818/53043781-8ea73f00-3489-11e9-8202-0fc5adb3056d.png)

Compared to current output, the following columns have been added:
1. *Datetime*. Date and time of the start of the activation in ISO format
2. *Kind*. The kind of the action, taken from the annotations of the activation. If undefined, *unknown* is output.
3. *Start*. If container was started warm or cold, as indicated by the *initTime* annotation in the activation record.
4. *Duration*. The duration of the activation. Provided in an appropriate measure, such as ms (milliseconds) or s (seconds).
5. *Status*. The outcome of the activation, as indicated by the *statusCode* attribute of the activation record and translated to a descriptive text.
6. *Entity*. The fully qualified entity name is provided as <namespace>/<package>/<name>:<version> 

I have signed an ICLA.