### PR TITLE
handle err return from url.Parse in GetUrlBase

### DIFF
--- a/whisk/wskprops.go
+++ b/whisk/wskprops.go
@@ -69,7 +69,7 @@ func GetUrlBase(host string) (*url.URL, error) {
 	urlBase := fmt.Sprintf("%s/api", host)
 	url, err := url.Parse(urlBase)
 
-	if len(url.Scheme) == 0 || len(url.Host) == 0 {
+	if err != nil || len(url.Scheme) == 0 || len(url.Host) == 0 {
 		urlBase = fmt.Sprintf("https://%s/api", host)
 		url, err = url.Parse(urlBase)
 	}


### PR DESCRIPTION
This is an attempt to fix wskdeploy issue https://github.com/apache/incubator-openwhisk-wskdeploy/issues/1050
which reported a crash in wskdeploy when the apihost
was a raw host:port without a scheme.